### PR TITLE
test: Add PBKDF2 100k iterations example

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -67,6 +67,13 @@ export default function App() {
         expected: 'boi+i61+rp2eEKoGEiQDT+1I0D8=',
       },
       {
+        key: 'pbkdf2-sha256-100k',
+        label:
+          'PBKDF2-SHA256 ("cGFzc3dvcmQ=", "c2FsdA==", 100000, 32) - High Iterations',
+        fn: () => pbkdf2Hash('cGFzc3dvcmQ=', 'c2FsdA==', 100000, 32, 'SHA256'), // "password", "salt", 100k iterations
+        expected: 'A5Si7eMyyaE+uC6bJGMWBMMd+Xi04vD70sVJlE+deaU=', // Expected value for 100k iterations
+      },
+      {
         key: 'hmac256-test1',
         label: 'HMAC-SHA256 (data="48656c6c6f", key="6b6579")', // "Hello", "key"
         fn: () => hmac256('48656c6c6f', '6b6579'),
@@ -491,6 +498,15 @@ export default function App() {
               {loading['pbkdf2-sha1']
                 ? 'Loading...'
                 : results['pbkdf2-sha1'] || 'Not run'}
+            </Text>
+
+            <Text style={styles.testLabel}>
+              PBKDF2-SHA256 (pwd="password", salt="salt", iter=100000, len=32):
+            </Text>
+            <Text style={styles.result}>
+              {loading['pbkdf2-sha256-100k']
+                ? 'Loading...'
+                : results['pbkdf2-sha256-100k'] || 'Not run'}
             </Text>
           </View>
 


### PR DESCRIPTION
PBKDF2 method already accepts iterations as a param, so I just added an example to confirm the functionality with 100k iterations.

| iOS  | Android  |
|---|---|
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/4c7a9bfd-bc65-4a7d-a954-b5ec6bc5e48b" />  | <img width="500" alt="image" src="https://github.com/user-attachments/assets/0abeeda6-cf66-42ad-b994-b98b31ad807d" />  |

https://rocketchat.atlassian.net/browse/ESH-22