### PR TITLE
fix: decode URL-encoded characters in E2E file paths

### DIFF
--- a/android/src/main/java/chat/rocket/mobilecrypto/algorithms/AESCrypto.kt
+++ b/android/src/main/java/chat/rocket/mobilecrypto/algorithms/AESCrypto.kt
@@ -7,6 +7,8 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.InputStream
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
@@ -115,7 +117,7 @@ object AESCrypto {
 
         return if (mode == "decrypt") {
             // Overwrite the input file with the decrypted file
-            val targetPath = if (inputFile.startsWith("file://")) inputFile.substring(7) else inputFile
+            val targetPath = normalizeFilePath(inputFile)
             FileInputStream(outputFileObj).use { inputStream ->
                 FileOutputStream(targetPath).use { fos ->
                     val buffer = ByteArray(BUFFER_SIZE)
@@ -194,10 +196,33 @@ object AESCrypto {
         val uri = Uri.parse(filePath)
 
         return if (uri.scheme == null || uri.scheme == "file") {
-            FileInputStream(uri.path ?: filePath)
+            // Use the decoded path for FileInputStream
+            val normalizedPath = normalizeFilePath(filePath)
+            FileInputStream(normalizedPath)
         } else {
             reactContext.contentResolver.openInputStream(uri)
                 ?: throw IllegalArgumentException("Cannot open input stream for URI: $uri")
+        }
+    }
+
+    /**
+     * Normalize file path by removing file:// prefix and decoding URL-encoded characters
+     * (e.g., %20 for spaces, %D0%9D for Cyrillic chars)
+     */
+    private fun normalizeFilePath(filePath: String): String {
+        var path = filePath
+
+        // Remove file:// prefix if present
+        if (path.startsWith("file://")) {
+            path = path.substring(7)
+        }
+
+        // Decode URL-encoded characters
+        return try {
+            URLDecoder.decode(path, StandardCharsets.UTF_8.toString())
+        } catch (e: Exception) {
+            // If decoding fails, return the original path
+            path
         }
     }
 }

--- a/android/src/main/java/chat/rocket/mobilecrypto/algorithms/AESCrypto.kt
+++ b/android/src/main/java/chat/rocket/mobilecrypto/algorithms/AESCrypto.kt
@@ -7,8 +7,6 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.InputStream
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
 import java.util.UUID
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
@@ -219,7 +217,7 @@ object AESCrypto {
 
         // Decode URL-encoded characters
         return try {
-            URLDecoder.decode(path, StandardCharsets.UTF_8.toString())
+            Uri.decode(path)
         } catch (e: Exception) {
             // If decoding fails, return the original path
             path

--- a/android/src/main/java/chat/rocket/mobilecrypto/algorithms/AESCrypto.kt
+++ b/android/src/main/java/chat/rocket/mobilecrypto/algorithms/AESCrypto.kt
@@ -115,9 +115,15 @@ object AESCrypto {
 
         return if (mode == "decrypt") {
             // Overwrite the input file with the decrypted file
-            val targetPath = normalizeFilePath(inputFile)
+            val targetUri = Uri.parse(inputFile)
             FileInputStream(outputFileObj).use { inputStream ->
-                FileOutputStream(targetPath).use { fos ->
+                val outputStream = if (targetUri.scheme == null || targetUri.scheme == "file") {
+                    FileOutputStream(normalizeFilePath(inputFile))
+                } else {
+                    reactContext.contentResolver.openOutputStream(targetUri)
+                        ?: throw IllegalArgumentException("Cannot open output stream for URI: $targetUri")
+                }
+                outputStream.use { fos ->
                     val buffer = ByteArray(BUFFER_SIZE)
                     var numBytesRead: Int
                     

--- a/android/src/main/java/chat/rocket/mobilecrypto/algorithms/AESCrypto.kt
+++ b/android/src/main/java/chat/rocket/mobilecrypto/algorithms/AESCrypto.kt
@@ -213,14 +213,13 @@ object AESCrypto {
         // Remove file:// prefix if present
         if (path.startsWith("file://")) {
             path = path.substring(7)
+            return try {
+                Uri.decode(path)
+            } catch (e: Exception) {
+                path
+            }
         }
 
-        // Decode URL-encoded characters
-        return try {
-            Uri.decode(path)
-        } catch (e: Exception) {
-            // If decoding fails, return the original path
-            path
-        }
+        return path
     }
 }

--- a/ios/algorithms/AESCrypto.m
+++ b/ios/algorithms/AESCrypto.m
@@ -87,15 +87,39 @@
     NSData *keyData = [CryptoUtils decodeBase64:keyBase64];
     NSData *ivData = [CryptoUtils decodeBase64:base64Iv];
 
-    NSString *path = [filePath stringByReplacingOccurrencesOfString:@"file://" withString:@""];
-    NSString *normalizedFilePath = [path stringByRemovingPercentEncoding] ?: path;
+    // Use NSURL to properly parse the file path and handle URL encoding
+    NSURL *fileURL = [NSURL URLWithString:filePath];
+    NSString *normalizedFilePath = [fileURL path];
+    if (!normalizedFilePath) {
+        // Fallback: strip file:// and decode
+        NSString *path = [filePath stringByReplacingOccurrencesOfString:@"file://" withString:@""];
+        normalizedFilePath = [path stringByRemovingPercentEncoding] ?: path;
+    }
+
+    // Check if input file exists
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if (![fileManager fileExistsAtPath:normalizedFilePath]) {
+        return nil;
+    }
+
     NSString *outputFileName = [@"processed_" stringByAppendingString:[normalizedFilePath lastPathComponent]];
     NSString *outputFilePath = [[normalizedFilePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:outputFileName];
-    
+
     NSInputStream *inputStream = [NSInputStream inputStreamWithFileAtPath:normalizedFilePath];
     NSOutputStream *outputStream = [NSOutputStream outputStreamToFileAtPath:outputFilePath append:NO];
+
+    // Validate stream creation
+    if (!inputStream || !outputStream) {
+        return nil;
+    }
+
     [inputStream open];
     [outputStream open];
+
+    // Validate stream opening
+    if ([inputStream streamStatus] != NSStreamStatusOpen || [outputStream streamStatus] != NSStreamStatusOpen) {
+        return nil;
+    }
 
     size_t bufferSize = 4096;
     uint8_t buffer[bufferSize];
@@ -108,40 +132,44 @@
         return nil;
     }
 
+    BOOL loopSuccess = YES;
+    size_t totalBytesRead = 0;
+    size_t totalBytesWritten = 0;
+
     while ([inputStream hasBytesAvailable]) {
         NSInteger bytesRead = [inputStream read:buffer maxLength:sizeof(buffer)];
         if (bytesRead > 0) {
+            totalBytesRead += bytesRead;
+
             size_t dataOutMoved;
             status = CCCryptorUpdate(cryptor, buffer, bytesRead, buffer, bufferSize, &dataOutMoved);
             if (status == kCCSuccess) {
-                [outputStream write:buffer maxLength:dataOutMoved];
+                NSInteger bytesWritten = [outputStream write:buffer maxLength:dataOutMoved];
+                if (bytesWritten != (NSInteger)dataOutMoved) {
+                    loopSuccess = NO;
+                    break;
+                }
+                totalBytesWritten += bytesWritten;
             } else {
                 NSLog(@"Cryptor update failed: %d", status);
-                CCCryptorRelease(cryptor);
-                [inputStream close];
-                [outputStream close];
-                return nil;
+                loopSuccess = NO;
+                break;
             }
         } else if (bytesRead < 0) {
             NSLog(@"Input stream read error");
-            CCCryptorRelease(cryptor);
-            [inputStream close];
-            [outputStream close];
-            return nil;
+            loopSuccess = NO;
+            break;
         }
     }
 
-    if (status == kCCSuccess) {
+    if (loopSuccess) {
         size_t finalBytesOut;
         status = CCCryptorFinal(cryptor, buffer, bufferSize, &finalBytesOut);
-        if (status == kCCSuccess) {
+        if (status == kCCSuccess && finalBytesOut > 0) {
             [outputStream write:buffer maxLength:finalBytesOut];
-        } else {
+            totalBytesWritten += finalBytesOut;
+        } else if (status != kCCSuccess) {
             NSLog(@"Cryptor final failed: %d", status);
-            CCCryptorRelease(cryptor);
-            [inputStream close];
-            [outputStream close];
-            return nil;
         }
     }
 
@@ -149,33 +177,33 @@
     [inputStream close];
     [outputStream close];
 
-    if (status == kCCSuccess) {
-        // For decrypt: return the temp file with sanitized name (to avoid issues with non-ASCII filenames)
-        NSString *originalName = [normalizedFilePath lastPathComponent];
-        NSString *sanitizedName = [originalName stringByReplacingOccurrencesOfString:@"[^a-zA-Z0-9._-]"
-                                                                          withString:@"_"
-                                                                             options:NSRegularExpressionSearch
-                                                                               range:NSMakeRange(0, originalName.length)];
-
-        // Create final file in cache directory with sanitized name
-        NSString *cachePath = NSTemporaryDirectory();
-        NSString *finalPath = [cachePath stringByAppendingPathComponent:[NSString stringWithFormat:@"decrypted_%@", sanitizedName]];
-
-        NSError *error = nil;
-        [[NSFileManager defaultManager] removeItemAtPath:finalPath error:nil]; // Remove if exists
-        [[NSFileManager defaultManager] copyItemAtPath:outputFilePath toPath:finalPath error:&error];
-        [[NSFileManager defaultManager] removeItemAtPath:outputFilePath error:nil];
-
-        if (error) {
-            NSLog(@"Failed to copy decrypted file: %@", error);
-            return nil;
-        }
-
-        NSLog(@"AESCrypto: Decrypted to temp file: %@", finalPath);
-        return [NSString stringWithFormat:@"file://%@", finalPath];
-    } else {
+    if (status != kCCSuccess || !loopSuccess) {
         [[NSFileManager defaultManager] removeItemAtPath:outputFilePath error:nil];
         return nil;
+    }
+
+    if (operation == kCCDecrypt) {
+        // For decrypt: overwrite the original file with decrypted content (matches Android behavior)
+        NSError *error = nil;
+        [[NSFileManager defaultManager] removeItemAtPath:normalizedFilePath error:nil];
+        [[NSFileManager defaultManager] moveItemAtPath:outputFilePath toPath:normalizedFilePath error:&error];
+
+        if (error) {
+            // Try copy as fallback
+            [[NSFileManager defaultManager] copyItemAtPath:outputFilePath toPath:normalizedFilePath error:&error];
+            [[NSFileManager defaultManager] removeItemAtPath:outputFilePath error:nil];
+            if (error) {
+                NSLog(@"Failed to overwrite decrypted file: %@", error);
+                return nil;
+            }
+        }
+
+        NSLog(@"AESCrypto: Decrypted successfully to: %@", normalizedFilePath);
+        // Return the original file path (matches Android behavior)
+        return [NSString stringWithFormat:@"file://%@", normalizedFilePath];
+    } else {
+        // For encrypt: return the processed file path
+        return [NSString stringWithFormat:@"file://%@", outputFilePath];
     }
 }
 

--- a/ios/algorithms/AESCrypto.m
+++ b/ios/algorithms/AESCrypto.m
@@ -114,6 +114,7 @@
     if ([inputStream streamStatus] != NSStreamStatusOpen || [outputStream streamStatus] != NSStreamStatusOpen) {
         [inputStream close];
         [outputStream close];
+        [fileManager removeItemAtPath:outputFilePath error:nil];
         return nil;
     }
 
@@ -125,6 +126,7 @@
         NSLog(@"Failed to create cryptor: %d", status);
         [inputStream close];
         [outputStream close];
+        [fileManager removeItemAtPath:outputFilePath error:nil];
         return nil;
     }
 

--- a/ios/algorithms/AESCrypto.m
+++ b/ios/algorithms/AESCrypto.m
@@ -118,6 +118,8 @@
 
     // Validate stream opening
     if ([inputStream streamStatus] != NSStreamStatusOpen || [outputStream streamStatus] != NSStreamStatusOpen) {
+        [inputStream close];
+        [outputStream close];
         return nil;
     }
 
@@ -183,23 +185,21 @@
     }
 
     if (operation == kCCDecrypt) {
-        // For decrypt: overwrite the original file with decrypted content (matches Android behavior)
+        // For decrypt: atomically replace the original file with decrypted content
+        NSURL *originalFileURL = [NSURL fileURLWithPath:normalizedFilePath];
+        NSURL *outputFileURL = [NSURL fileURLWithPath:outputFilePath];
         NSError *error = nil;
-        [[NSFileManager defaultManager] removeItemAtPath:normalizedFilePath error:nil];
-        [[NSFileManager defaultManager] moveItemAtPath:outputFilePath toPath:normalizedFilePath error:&error];
-
-        if (error) {
-            // Try copy as fallback
-            [[NSFileManager defaultManager] copyItemAtPath:outputFilePath toPath:normalizedFilePath error:&error];
+        BOOL success = [[NSFileManager defaultManager] replaceItemAtURL:originalFileURL
+                                                      withItemAtURL:outputFileURL
+                                                     backupItemName:nil
+                                                            options:NSFileManagerItemReplacementUsingNewMetadataOnly
+                                                   resultingItemURL:nil
+                                                              error:&error];
+        if (!success) {
+            NSLog(@"Failed to replace original file: %@", error);
             [[NSFileManager defaultManager] removeItemAtPath:outputFilePath error:nil];
-            if (error) {
-                NSLog(@"Failed to overwrite decrypted file: %@", error);
-                return nil;
-            }
+            return nil;
         }
-
-        NSLog(@"AESCrypto: Decrypted successfully to: %@", normalizedFilePath);
-        // Return the original file path (matches Android behavior)
         return [NSString stringWithFormat:@"file://%@", normalizedFilePath];
     } else {
         // For encrypt: return the processed file path

--- a/ios/algorithms/AESCrypto.m
+++ b/ios/algorithms/AESCrypto.m
@@ -1,5 +1,6 @@
 #import "AESCrypto.h"
 #import "CryptoUtils.h"
+#import "FileUtils.h"
 #import <CommonCrypto/CommonCryptor.h>
 
 #import <MobileCrypto/MobileCrypto-Swift.h>
@@ -87,14 +88,7 @@
     NSData *keyData = [CryptoUtils decodeBase64:keyBase64];
     NSData *ivData = [CryptoUtils decodeBase64:base64Iv];
 
-    // Use NSURL to properly parse the file path and handle URL encoding
-    NSURL *fileURL = [NSURL URLWithString:filePath];
-    NSString *normalizedFilePath = [fileURL path];
-    if (!normalizedFilePath) {
-        // Fallback: strip file:// and decode
-        NSString *path = [filePath stringByReplacingOccurrencesOfString:@"file://" withString:@""];
-        normalizedFilePath = [path stringByRemovingPercentEncoding] ?: path;
-    }
+    NSString *normalizedFilePath = [FileUtils normalizeFilePath:filePath];
 
     // Check if input file exists
     NSFileManager *fileManager = [NSFileManager defaultManager];

--- a/ios/algorithms/AESCrypto.m
+++ b/ios/algorithms/AESCrypto.m
@@ -135,13 +135,10 @@
     }
 
     BOOL loopSuccess = YES;
-    size_t totalBytesRead = 0;
-    size_t totalBytesWritten = 0;
 
     while ([inputStream hasBytesAvailable]) {
         NSInteger bytesRead = [inputStream read:buffer maxLength:sizeof(buffer)];
         if (bytesRead > 0) {
-            totalBytesRead += bytesRead;
 
             size_t dataOutMoved;
             status = CCCryptorUpdate(cryptor, buffer, bytesRead, buffer, bufferSize, &dataOutMoved);
@@ -151,7 +148,6 @@
                     loopSuccess = NO;
                     break;
                 }
-                totalBytesWritten += bytesWritten;
             } else {
                 NSLog(@"Cryptor update failed: %d", status);
                 loopSuccess = NO;
@@ -169,7 +165,6 @@
         status = CCCryptorFinal(cryptor, buffer, bufferSize, &finalBytesOut);
         if (status == kCCSuccess && finalBytesOut > 0) {
             [outputStream write:buffer maxLength:finalBytesOut];
-            totalBytesWritten += finalBytesOut;
         } else if (status != kCCSuccess) {
             NSLog(@"Cryptor final failed: %d", status);
         }
@@ -189,13 +184,13 @@
         NSURL *originalFileURL = [NSURL fileURLWithPath:normalizedFilePath];
         NSURL *outputFileURL = [NSURL fileURLWithPath:outputFilePath];
         NSError *error = nil;
-        BOOL success = [[NSFileManager defaultManager] replaceItemAtURL:originalFileURL
-                                                      withItemAtURL:outputFileURL
-                                                     backupItemName:nil
-                                                            options:NSFileManagerItemReplacementUsingNewMetadataOnly
-                                                   resultingItemURL:nil
-                                                              error:&error];
-        if (!success) {
+        NSURL *replacedURL = [[NSFileManager defaultManager] replaceItemAtURL:originalFileURL
+                                                             withItemAtURL:outputFileURL
+                                                            backupItemName:nil
+                                                                   options:NSFileManagerItemReplacementUsingNewMetadataOnly
+                                                          resultingItemURL:nil
+                                                                     error:&error];
+        if (!replacedURL) {
             NSLog(@"Failed to replace original file: %@", error);
             [[NSFileManager defaultManager] removeItemAtPath:outputFilePath error:nil];
             return nil;

--- a/ios/algorithms/AESCrypto.m
+++ b/ios/algorithms/AESCrypto.m
@@ -87,7 +87,8 @@
     NSData *keyData = [CryptoUtils decodeBase64:keyBase64];
     NSData *ivData = [CryptoUtils decodeBase64:base64Iv];
 
-    NSString *normalizedFilePath = [filePath stringByReplacingOccurrencesOfString:@"file://" withString:@""];
+    NSString *path = [filePath stringByReplacingOccurrencesOfString:@"file://" withString:@""];
+    NSString *normalizedFilePath = [path stringByRemovingPercentEncoding] ?: path;
     NSString *outputFileName = [@"processed_" stringByAppendingString:[normalizedFilePath lastPathComponent]];
     NSString *outputFilePath = [[normalizedFilePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:outputFileName];
     
@@ -149,20 +150,29 @@
     [outputStream close];
 
     if (status == kCCSuccess) {
-        NSURL *originalFileURL = [NSURL fileURLWithPath:normalizedFilePath];
-        NSURL *outputFileURL = [NSURL fileURLWithPath:outputFilePath];
+        // For decrypt: return the temp file with sanitized name (to avoid issues with non-ASCII filenames)
+        NSString *originalName = [normalizedFilePath lastPathComponent];
+        NSString *sanitizedName = [originalName stringByReplacingOccurrencesOfString:@"[^a-zA-Z0-9._-]"
+                                                                          withString:@"_"
+                                                                             options:NSRegularExpressionSearch
+                                                                               range:NSMakeRange(0, originalName.length)];
+
+        // Create final file in cache directory with sanitized name
+        NSString *cachePath = NSTemporaryDirectory();
+        NSString *finalPath = [cachePath stringByAppendingPathComponent:[NSString stringWithFormat:@"decrypted_%@", sanitizedName]];
+
         NSError *error = nil;
-        [[NSFileManager defaultManager] replaceItemAtURL:originalFileURL
-                                          withItemAtURL:outputFileURL
-                                         backupItemName:nil
-                                                options:NSFileManagerItemReplacementUsingNewMetadataOnly
-                                       resultingItemURL:nil
-                                                  error:&error];
+        [[NSFileManager defaultManager] removeItemAtPath:finalPath error:nil]; // Remove if exists
+        [[NSFileManager defaultManager] copyItemAtPath:outputFilePath toPath:finalPath error:&error];
+        [[NSFileManager defaultManager] removeItemAtPath:outputFilePath error:nil];
+
         if (error) {
-            NSLog(@"Failed to replace original file: %@", error);
+            NSLog(@"Failed to copy decrypted file: %@", error);
             return nil;
         }
-        return [NSString stringWithFormat:@"file://%@", normalizedFilePath];
+
+        NSLog(@"AESCrypto: Decrypted to temp file: %@", finalPath);
+        return [NSString stringWithFormat:@"file://%@", finalPath];
     } else {
         [[NSFileManager defaultManager] removeItemAtPath:outputFilePath error:nil];
         return nil;

--- a/ios/algorithms/AESCrypto.m
+++ b/ios/algorithms/AESCrypto.m
@@ -160,7 +160,11 @@
         size_t finalBytesOut;
         status = CCCryptorFinal(cryptor, buffer, bufferSize, &finalBytesOut);
         if (status == kCCSuccess && finalBytesOut > 0) {
-            [outputStream write:buffer maxLength:finalBytesOut];
+            NSInteger finalBytesWritten = [outputStream write:buffer maxLength:finalBytesOut];
+            if (finalBytesWritten != (NSInteger)finalBytesOut) {
+                NSLog(@"Output stream write error on final block");
+                loopSuccess = NO;
+            }
         } else if (status != kCCSuccess) {
             NSLog(@"Cryptor final failed: %d", status);
         }

--- a/ios/algorithms/AESCrypto.m
+++ b/ios/algorithms/AESCrypto.m
@@ -180,13 +180,13 @@
         NSURL *originalFileURL = [NSURL fileURLWithPath:normalizedFilePath];
         NSURL *outputFileURL = [NSURL fileURLWithPath:outputFilePath];
         NSError *error = nil;
-        NSURL *replacedURL = [[NSFileManager defaultManager] replaceItemAtURL:originalFileURL
-                                                             withItemAtURL:outputFileURL
-                                                            backupItemName:nil
-                                                                   options:NSFileManagerItemReplacementUsingNewMetadataOnly
-                                                          resultingItemURL:nil
-                                                                     error:&error];
-        if (!replacedURL) {
+        BOOL success = [[NSFileManager defaultManager] replaceItemAtURL:originalFileURL
+                                                           withItemAtURL:outputFileURL
+                                                          backupItemName:nil
+                                                                 options:NSFileManagerItemReplacementUsingNewMetadataOnly
+                                                        resultingItemURL:nil
+                                                                   error:&error];
+        if (!success) {
             NSLog(@"Failed to replace original file: %@", error);
             [[NSFileManager defaultManager] removeItemAtPath:outputFilePath error:nil];
             return nil;

--- a/ios/algorithms/FileUtils.m
+++ b/ios/algorithms/FileUtils.m
@@ -220,10 +220,15 @@ static const NSUInteger BUFFER_SIZE = 4096;
 }
 
 + (NSString *)normalizeFilePath:(NSString *)filePath {
-    if ([filePath hasPrefix:@"file://"]) {
-        return [filePath substringFromIndex:7];
+    NSString *path = filePath;
+
+    if ([path hasPrefix:@"file://"]) {
+        path = [path substringFromIndex:7];
     }
-    return filePath;
+
+    // Decode URL-encoded characters (e.g., %20 for spaces, %D0%9D for Cyrillic chars)
+    NSString *decodedPath = [path stringByRemovingPercentEncoding];
+    return decodedPath ?: path;
 }
 
 @end

--- a/ios/algorithms/FileUtils.m
+++ b/ios/algorithms/FileUtils.m
@@ -224,11 +224,11 @@ static const NSUInteger BUFFER_SIZE = 4096;
 
     if ([path hasPrefix:@"file://"]) {
         path = [path substringFromIndex:7];
+        NSString *decodedPath = [path stringByRemovingPercentEncoding];
+        return decodedPath ?: path;
     }
 
-    // Decode URL-encoded characters (e.g., %20 for spaces, %D0%9D for Cyrillic chars)
-    NSString *decodedPath = [path stringByRemovingPercentEncoding];
-    return decodedPath ?: path;
+    return path;
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/mobile-crypto",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Rocket.Chat Mobile Crypto",
   "main": "./lib/module/index.js",
   "module": "./lib/module/index.js",


### PR DESCRIPTION
## Issue
When decrypting E2E (end-to-end encrypted) files, file names containing non-ASCII characters (spaces, Cyrillic, etc.) would display URL-encoded literals instead of the actual characters.

**Example:**
- Expected: `Наименование.txt`
- Actual: `Наименование.txt` (or `%D0%9D%D0%B0...`)

http://rocketchat.atlassian.net/browse/SUP-1007

## Root Cause
File URIs (`file://`) from the Android/iOS file system contain URL-encoded paths (e.g., `%20` for spaces, `%D0%9D` for Cyrillic). The native decryption code was not decoding these paths before using them, resulting in the encoded literals appearing in file names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AES encryption/decryption for base64 strings and files, including GCM and CTR modes.

* **Bug Fixes**
  * Safer cross-platform file handling: normalized and URL-decoded paths, input existence and stream checks, write validation, support for non-file URIs, and atomic replacement on successful decrypts.

* **Chores**
  * Version bumped to 0.2.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->