### PR TITLE
feat(android): migrate from SpongyCastle to BouncyCastle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -78,6 +78,5 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.madgag.spongycastle:core:1.58.0.0"
-  implementation "com.madgag.spongycastle:prov:1.58.0.0"
+  implementation "org.bouncycastle:bcprov-jdk18on:1.84"
 }

--- a/android/src/main/java/chat/rocket/mobilecrypto/algorithms/PBKDF2Crypto.kt
+++ b/android/src/main/java/chat/rocket/mobilecrypto/algorithms/PBKDF2Crypto.kt
@@ -1,15 +1,15 @@
 package chat.rocket.mobilecrypto.algorithms
 
 import java.security.NoSuchAlgorithmException
-import org.spongycastle.crypto.ExtendedDigest
-import org.spongycastle.crypto.PBEParametersGenerator
-import org.spongycastle.crypto.digests.SHA1Digest
-import org.spongycastle.crypto.digests.SHA224Digest
-import org.spongycastle.crypto.digests.SHA256Digest
-import org.spongycastle.crypto.digests.SHA384Digest
-import org.spongycastle.crypto.digests.SHA512Digest
-import org.spongycastle.crypto.generators.PKCS5S2ParametersGenerator
-import org.spongycastle.crypto.params.KeyParameter
+import org.bouncycastle.crypto.ExtendedDigest
+import org.bouncycastle.crypto.PBEParametersGenerator
+import org.bouncycastle.crypto.digests.SHA1Digest
+import org.bouncycastle.crypto.digests.SHA224Digest
+import org.bouncycastle.crypto.digests.SHA256Digest
+import org.bouncycastle.crypto.digests.SHA384Digest
+import org.bouncycastle.crypto.digests.SHA512Digest
+import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator
+import org.bouncycastle.crypto.params.KeyParameter
 
 /**
  * PBKDF2 (Password-Based Key Derivation Function 2) operations

--- a/android/src/main/java/chat/rocket/mobilecrypto/algorithms/RSACrypto.kt
+++ b/android/src/main/java/chat/rocket/mobilecrypto/algorithms/RSACrypto.kt
@@ -21,13 +21,13 @@ import java.security.spec.RSAPublicKeySpec
 import java.security.spec.X509EncodedKeySpec
 import java.util.Arrays
 import javax.crypto.Cipher
-import org.spongycastle.asn1.ASN1InputStream
-import org.spongycastle.asn1.ASN1Primitive
-import org.spongycastle.asn1.pkcs.PrivateKeyInfo
-import org.spongycastle.asn1.x509.SubjectPublicKeyInfo
-import org.spongycastle.util.io.pem.PemObject
-import org.spongycastle.util.io.pem.PemReader
-import org.spongycastle.util.io.pem.PemWriter
+import org.bouncycastle.asn1.ASN1InputStream
+import org.bouncycastle.asn1.ASN1Primitive
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.util.io.pem.PemObject
+import org.bouncycastle.util.io.pem.PemReader
+import org.bouncycastle.util.io.pem.PemWriter
 
 /**
  * RSA encryption, decryption, signing and key format conversion operations
@@ -318,7 +318,7 @@ object RSACrypto {
             // PKCS#1 RSA PUBLIC KEY format - need to convert to X.509
             val inputStream = ASN1InputStream(keyData)
             val obj = inputStream.readObject()
-            val rsaPublicKey = org.spongycastle.asn1.pkcs.RSAPublicKey.getInstance(obj)
+            val rsaPublicKey = org.bouncycastle.asn1.pkcs.RSAPublicKey.getInstance(obj)
             
             val keySpec = RSAPublicKeySpec(rsaPublicKey.modulus, rsaPublicKey.publicExponent)
             keyFactory.generatePublic(keySpec)
@@ -412,7 +412,7 @@ object RSACrypto {
     }
 
     private fun pkcs1ToPublicKey(obj: ASN1Primitive): WritableMap {
-        val keyStruct = org.spongycastle.asn1.pkcs.RSAPublicKey.getInstance(obj)
+        val keyStruct = org.bouncycastle.asn1.pkcs.RSAPublicKey.getInstance(obj)
 
         val jwk = Arguments.createMap()
         jwk.putString("n", toBase64String(keyStruct.modulus, true))
@@ -422,7 +422,7 @@ object RSACrypto {
     }
 
     private fun pkcs1ToPrivateKey(obj: ASN1Primitive): WritableMap {
-        val keyStruct = org.spongycastle.asn1.pkcs.RSAPrivateKey.getInstance(obj)
+        val keyStruct = org.bouncycastle.asn1.pkcs.RSAPrivateKey.getInstance(obj)
 
         val jwk = Arguments.createMap()
         jwk.putString("n", toBase64String(keyStruct.modulus, true))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/mobile-crypto",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Rocket.Chat Mobile Crypto",
   "main": "./lib/module/index.js",
   "module": "./lib/module/index.js",


### PR DESCRIPTION
## Summary

Migrates the Android implementation off the unmaintained SpongyCastle fork (`com.madgag.spongycastle:core` + `:prov` 1.58.0.0) to BouncyCastle `org.bouncycastle:bcprov-jdk18on:1.84` (latest on Maven Central).

SpongyCastle is a package-renamed BouncyCastle fork, so this is a pure mechanical swap:

- `android/build.gradle`: 2 deps → 1 (`bcprov-jdk18on` covers everything previously supplied by `core`+`prov` for the classes used: `crypto.digests/generators/params`, `asn1.*`, `util.io.pem`)
- `PBKDF2Crypto.kt` + `RSACrypto.kt`: `org.spongycastle.*` → `org.bouncycastle.*` (imports + fully-qualified refs). Class names identical, no logic changes.

The library is used as plain classes only — never registered as a JCE provider (no `Security.addProvider`), so there is no collision with Android's platform BC (`com.android.org.bouncycastle` namespace).

No iOS, TypeScript, CI, or ProGuard changes. Zero `spongycastle`/`madgag` references remain repo-wide.

## Verification

Known-answer harness (`example/src/App.tsx`) on Android emulator (API 36): **31/31 entries pass**, including the fixed-vector KATs (RSA OAEP-SHA256 decrypt, deterministic PKCS#1 v1.5 SHA-256 sign exact-match, JWK export fixed n/e, JWK import→verify) that compare against literal pinned bytes from before the migration — proving byte-compatibility for E2E encryption. KAT expected values are shared with iOS, so cross-platform equality holds by construction.

Unit tests are deliberately out of scope — tracked separately in NATIVE-1378.

Jira: NATIVE-1284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s cryptography backend to use a newer Bouncy Castle provider.
  * Improved compatibility for RSA and PBKDF2 key handling while keeping existing encryption behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->